### PR TITLE
Decompile 6 low-match functions from PR #49

### DIFF
--- a/include/ps2/veronica/prog/en16.h
+++ b/include/ps2/veronica/prog/en16.h
@@ -12,7 +12,7 @@ void bhEne16_MV00(BH_PWORK* epw);
 void bhEne16_MV01(BH_PWORK* epw);
 void bhEne16_MV02(BH_PWORK* epw);
 int bhEne16_GetEffNum(BH_PWORK* epw);
-/*_anon14* bhEne16_GetEffPos(BH_PWORK* epw);
-void bhEne16_AddEffPos(BH_PWORK* epw, _anon14* pos);*/
+NJS_POINT3* bhEne16_GetEffPos(BH_PWORK* epw);
+void bhEne16_AddEffPos(BH_PWORK* epw, NJS_POINT3* pos);
 
 #endif

--- a/src/ps2/veronica/prog/effsub2.c
+++ b/src/ps2/veronica/prog/effsub2.c
@@ -2088,7 +2088,145 @@ void bhEff_E11_SearchLight(O_WRK* op)
 
 // 
 // Start address: 0x2411a0
+typedef struct {
+	void* p;
+	void* col;
+	void* tex;
+	unsigned int num;
+} P3COL_DESC;
+
 void bhEff_E11_SearchLightDraw(O_WRK* op)
+{
+	float ratetbl[16];
+	int i;
+	float ang;
+	float cx, cy;
+	float dir[4];
+	float* mtxp;
+	unsigned char* ownerp;
+	unsigned char* segp;
+	NJS_POINT3 pts[3];
+	unsigned char attrbuf[12];
+	P3COL_DESC desc;
+	NJS_POINT3 base;
+	float f20, f21;
+	NJS_SYS_ATTR sysattr;
+
+	ownerp = (unsigned char*)((BH_PWORK*)op->lkwkp)->mlwP->owP;
+	segp = ownerp + 0x150;
+	base.x = *(float*)(ownerp + 0x180);
+	base.y = *(float*)(ownerp + 0x184);
+	base.z = *(float*)(ownerp + 0x188);
+	mtxp = (float*)(op->exp0 + 4);
+
+	for (i = 0; i < 0x10; i++) {
+		ang = 182.04445f * (float)(i * 16);
+		f20 = 100.0f * njCos((int)ang);
+		cx = f20 * tanf(0.0000958738f * (float)op->ax);
+		f21 = tanf(0.0000958738f * (float)op->ax);
+		cy = 100.0f * njSin((int)ang) * f21;
+		dir[0] = cx;
+		dir[1] = cy;
+		dir[2] = 0.0f;
+		dir[3] = 0.0f;
+		njUnitVector((NJS_VECTOR*)dir);
+		njCalcVector((NJS_MATRIX*)segp, (NJS_VECTOR*)dir, (NJS_VECTOR*)dir);
+		njCalcVector((NJS_MATRIX*)cam.mtx, (NJS_VECTOR*)dir, (NJS_VECTOR*)dir);
+		if (dir[3] > 0.0f) {
+			ratetbl[i] = dir[3] - 0.3f;
+			if (ratetbl[i] < 0.0f) ratetbl[i] = 0.0f;
+			if (ratetbl[i] > 0.5f) ratetbl[i] = 0.5f;
+		} else {
+			ratetbl[i] = (-dir[3] - 0.3f) * 1.6f;
+			if (ratetbl[i] < 0.0f) ratetbl[i] = 0.0f;
+			if (ratetbl[i] > 1.0f) ratetbl[i] = 1.0f;
+		}
+
+		if (sys->sp_flg & 8) {
+			njCalcPoint((NJS_MATRIX*)segp, (NJS_VECTOR*)&cx, (NJS_POINT3*)mtxp);
+			bhCollisionCheckLine2((NJS_POINT3*)&base, (NJS_POINT3*)mtxp, 0x4400, -1);
+			if (bhEff_E11_CheckCollisionPlayer((NJS_POINT3*)&base, (NJS_POINT3*)mtxp) != -1 && op->mode0 == 2) {
+				op->ct2 = 1;
+			}
+		}
+		mtxp += 3;
+	}
+
+	njGetSystemAttr(&sysattr);
+	njColorBlendingMode(0, 8);
+	njColorBlendingMode(1, 0xA);
+	njFogDisable();
+	njSetMatrix(0, (void*)cam.mtx);
+
+	desc.p = pts;
+	desc.col = attrbuf;
+	desc.tex = 0;
+	desc.num = 3;
+
+	if (op->ct2 != 0) {
+		attrbuf[3] = (unsigned char)(150.0f + (55.0f * op->sx));
+		attrbuf[2] = op->ct0 * 3;
+		attrbuf[1] = 0;
+		attrbuf[0] = 0;
+		attrbuf[6] = op->ct0 * 2;
+		attrbuf[5] = 0;
+		attrbuf[4] = 0;
+	} else {
+		attrbuf[3] = (unsigned char)(150.0f + (55.0f * op->sx));
+		attrbuf[2] = (unsigned char)(0.8f * (float)op->ct0);
+		attrbuf[1] = (unsigned char)(0.8f * (float)op->ct0);
+		attrbuf[0] = op->ct0;
+		attrbuf[6] = (unsigned char)(0.4f * (float)op->ct0);
+		attrbuf[5] = (unsigned char)(0.4f * (float)op->ct0);
+		attrbuf[4] = op->ct0;
+	}
+
+	mtxp = (float*)(op->exp0 + 4);
+	pts[0] = base;
+	for (i = 0; i < 0xF; i++) {
+		pts[1].x = mtxp[0];
+		pts[1].y = mtxp[1];
+		pts[1].z = mtxp[2];
+		pts[2].x = mtxp[3];
+		pts[2].y = mtxp[4];
+		pts[2].z = mtxp[5];
+		attrbuf[7] = (unsigned char)((30.0f + (15.0f * op->sx)) * ratetbl[i]);
+		attrbuf[11] = (unsigned char)((30.0f + (15.0f * op->sx)) * ratetbl[i + 1]);
+		njDrawPolygon3D((NJS_POINT3COL*)&desc, 3, 0x60);
+		mtxp += 3;
+	}
+	pts[1].x = mtxp[0];
+	pts[1].y = mtxp[1];
+	pts[1].z = mtxp[2];
+	pts[2] = pts[0];
+	attrbuf[7] = (unsigned char)((30.0f + (15.0f * op->sx)) * ratetbl[0xF]);
+	attrbuf[11] = (unsigned char)((30.0f + (15.0f * op->sx)) * ratetbl[0]);
+	njDrawPolygon3D((NJS_POINT3COL*)&desc, 3, 0x60);
+
+	desc.p = pts;
+	desc.col = attrbuf;
+	desc.num = 2;
+	pts[0] = base;
+	pts[1] = base;
+	attrbuf[3] = (unsigned char)(64.0f * op->sy);
+	attrbuf[2] = (unsigned char)op->ct2 << 6;
+	attrbuf[1] = (unsigned char)(1 - op->ct2) << 6;
+	attrbuf[0] = 0;
+	attrbuf[7] = (unsigned char)(128.0f * op->sz);
+	attrbuf[6] = (unsigned char)op->ct2 << 6;
+	attrbuf[5] = (unsigned char)(1 - op->ct2) << 6;
+	attrbuf[4] = 0;
+	njDrawLine3DEx((NJS_POINT3COL*)&desc, 1, 0x40);
+	njDrawLine3DEx((NJS_POINT3COL*)&desc, 1, 0x40, ((op->ct1 >> 4) + 8) & 0xF);
+
+	njSetSystemAttr(&sysattr);
+	if (sys->st_flg & 2) {
+		njFogEnable();
+	}
+}
+
+#if 0
+void bhEff_E11_SearchLightDraw_orig(O_WRK* op)
 {
 	float rate;
 	int id2;
@@ -2276,6 +2414,7 @@ void bhEff_E11_SearchLightDraw(O_WRK* op)
 	// Func End, Address: 0x241a04, Func Offset: 0x864
 	scePrintf("bhEff_E11_SearchLightDraw - UNIMPLEMENTED!\n");
 }
+#endif
 
 // 100% matching!
 int bhEff_E11_CheckCollisionPlayer(NJS_POINT3* p1, NJS_POINT3* p2)
@@ -2373,7 +2512,152 @@ void bhEff_E16_LaserSight(O_WRK* op)
 
 // 
 // Start address: 0x241ca0
+extern NJS_POINT3* bhEne16_GetEffPos(BH_PWORK* epw);
+extern void bhEne16_AddEffPos(BH_PWORK* epw, NJS_POINT3* pos);
+
 void bhEff_E16_LaserSightDraw(O_WRK* op)
+{
+	NJS_POINT3 dirtbl[16];
+	float ratetbl[16];
+	BH_PWORK* ep;
+	NJS_POINT3* effp;
+	int num;
+	float* mtxp;
+	unsigned char* ownerp;
+	unsigned char* ent;
+	NJS_POINT3 base;
+	NJS_POINT3 hit;
+	float dir[4];
+	int i;
+	float ang;
+	float ln;
+	NJS_POINT3 pts2[2];
+	unsigned char attr2[8];
+	P3COL_DESC desc2;
+	NJS_POINT3 pts3[3];
+	unsigned char attr3[12];
+	P3COL_DESC desc3;
+	NJS_SYS_ATTR sysattr;
+
+	ownerp = (unsigned char*)((BH_PWORK*)op->lkwkp)->mlwP->owP;
+	ent = ownerp + (op->lkono * 0x50);
+	mtxp = (float*)(ent + 0x10);
+	base.x = *(float*)(ent + 0x40);
+	base.y = *(float*)(ent + 0x44);
+	base.z = *(float*)(ent + 0x48);
+
+	hit.x = 0.0f;
+	hit.y = 0.0f;
+	hit.z = -1500.0f;
+	njCalcPoint((NJS_MATRIX*)mtxp, (NJS_POINT3*)&hit, (NJS_POINT3*)&hit);
+	if (sys->sp_flg & 8) {
+		op->exp0 = (unsigned char*)bhCollisionCheckLine2((NJS_POINT3*)&base, (NJS_POINT3*)&hit, 0x4400, -1);
+		op->lox = hit.x;
+		op->loy = hit.y;
+		op->loz = hit.z;
+		op->ct0 = bhEff_E11_CheckCollisionPlayer((NJS_POINT3*)&base, (NJS_POINT3*)&hit);
+		op->gpx = hit.x;
+		op->gpy = hit.y;
+		op->gpz = hit.z;
+		bhEne16_AddEffPos((BH_PWORK*)op->lkwkp, (NJS_POINT3*)&hit);
+	} else {
+		hit.x = op->gpx;
+		hit.y = op->gpy;
+		hit.z = op->gpz;
+	}
+
+	ln = -njDistanceP2P((NJS_POINT3*)&base, (NJS_POINT3*)&hit);
+	for (i = 0; i < 0x10; i++) {
+		ang = 182.04445f * (float)(i * 16);
+		dirtbl[i].x = 0.07f * njCos((int)ang);
+		dirtbl[i].y = 0.07f * njSin((int)ang);
+		dirtbl[i].z = ln;
+		njCalcPoint4((NJS_MATRIX*)mtxp, (NJS_POINT4*)&dirtbl[i], (NJS_POINT4*)&dirtbl[i]);
+		dir[0] = dirtbl[i].x;
+		dir[1] = dirtbl[i].y;
+		dir[2] = 0.0f;
+		njUnitVector((NJS_VECTOR*)dir);
+		njCalcVector((NJS_MATRIX*)mtxp, (NJS_VECTOR*)dir, (NJS_VECTOR*)dir);
+		njCalcVector((NJS_MATRIX*)cam.mtx, (NJS_VECTOR*)dir, (NJS_VECTOR*)dir);
+		if (dir[2] > 0.0f) {
+			ratetbl[i] = 0.0f;
+		} else {
+			ratetbl[i] = (-dir[2] - 0.3f) * 1.6f;
+			if (ratetbl[i] < 0.0f) ratetbl[i] = 0.0f;
+			if (ratetbl[i] > 1.0f) ratetbl[i] = 1.0f;
+		}
+	}
+
+	njGetSystemAttr(&sysattr);
+	njColorBlendingMode(0, 8);
+	njColorBlendingMode(1, 0xA);
+	njFogDisable();
+	njSetMatrix(0, (void*)cam.mtx);
+
+	desc2.p = pts2;
+	desc2.col = attr2;
+	desc2.tex = 0;
+	desc2.num = 2;
+	pts2[0] = base;
+	pts2[1] = hit;
+	attr2[3] = 0x40;
+	attr2[2] = 0x40;
+	attr2[1] = 0;
+	attr2[0] = 0;
+	attr2[7] = 0x80;
+	attr2[6] = 0x40;
+	attr2[5] = 0;
+	attr2[4] = 0;
+	njDrawLine3DEx((NJS_POINT3COL*)&desc2, 1, 0x40);
+
+	ep = (BH_PWORK*)op->lkwkp;
+	if (ep->type != 0) {
+		num = bhEne16_GetEffNum(ep);
+		effp = (NJS_POINT3*)bhEne16_GetEffPos(ep);
+		for (i = 0; i < num; i++) {
+			pts2[1] = effp[i];
+			attr2[7] = 0x28 - (i * 4);
+			attr2[3] = 0x28 - (i * 4);
+			njDrawLine3DEx((NJS_POINT3COL*)&desc2, 1, 0x40);
+		}
+	}
+
+	desc3.p = pts3;
+	desc3.col = attr3;
+	desc3.tex = 0;
+	desc3.num = 3;
+	pts3[0] = base;
+	attr3[0] = 0;
+	attr3[1] = 0;
+	attr3[2] = 0;
+	attr3[3] = 0;
+	for (i = 0; i < 0xF; i++) {
+		pts3[1] = dirtbl[i];
+		pts3[2] = dirtbl[i + 1];
+		attr3[4] = 0;
+		attr3[5] = 0;
+		attr3[6] = 0x64;
+		attr3[7] = (unsigned char)(255.0f * ratetbl[i]);
+		attr3[8] = 0;
+		attr3[9] = 0;
+		attr3[10] = 0x64;
+		attr3[11] = (unsigned char)(255.0f * ratetbl[i + 1]);
+		njDrawPolygon3D((NJS_POINT3COL*)&desc3, 3, 0x60);
+	}
+	pts3[1] = dirtbl[0xF];
+	pts3[2] = dirtbl[0];
+	attr3[7] = (unsigned char)(255.0f * ratetbl[0xF]);
+	attr3[11] = (unsigned char)(255.0f * ratetbl[0]);
+	njDrawPolygon3D((NJS_POINT3COL*)&desc3, 3, 0x60);
+
+	njSetSystemAttr(&sysattr);
+	if (sys->st_flg & 2) {
+		njFogEnable();
+	}
+}
+
+#if 0
+void bhEff_E16_LaserSightDraw_orig(O_WRK* op)
 {
 	//_anon45 p3c;
 	NJS_POINT3 area[3];
@@ -2587,10 +2871,210 @@ void bhEff_E16_LaserSightDraw(O_WRK* op)
 	// Func End, Address: 0x242318, Func Offset: 0x678
 	scePrintf("bhEff_E16_LaserSightDraw - UNIMPLEMENTED!\n");
 }
+#endif
 
 // 
 // Start address: 0x242320
 void bhEff_E12_Fire(O_WRK* op)
+{
+	static UV_WORK BH_UVTAB0[10] = {
+		{ 0.0f, 0.0f, 0.15625f, 0.1875f },
+		{ 0.1875f, 0.0f, 0.15625f, 0.1875f },
+		{ 0.375f, 0.0f, 0.15625f, 0.1875f },
+		{ 0.5625f, 0.0f, 0.15625f, 0.1875f },
+		{ 0.75f, 0.0f, 0.15625f, 0.1875f },
+		{ 0.0f, 0.1875f, 0.15625f, 0.1875f },
+		{ 0.1875f, 0.1875f, 0.15625f, 0.1875f },
+		{ 0.375f, 0.1875f, 0.15625f, 0.1875f },
+		{ 0.5625f, 0.1875f, 0.15625f, 0.1875f },
+		{ -1.0f, 0.0f, 0.0f, 0.0f },
+	};
+	static UV_WORK BH_UVTAB1[9] = {
+		{ 0.03125f, 0.46875f, 0.15625f, 0.21875f },
+		{ 0.25f, 0.46875f, 0.15625f, 0.21875f },
+		{ 0.46875f, 0.46875f, 0.15625f, 0.21875f },
+		{ 0.6875f, 0.46875f, 0.15625f, 0.21875f },
+		{ 0.03125f, 0.6875f, 0.15625f, 0.21875f },
+		{ 0.25f, 0.6875f, 0.15625f, 0.21875f },
+		{ 0.46875f, 0.6875f, 0.15625f, 0.21875f },
+		{ 0.6875f, 0.6875f, 0.15625f, 0.21875f },
+		{ -1.0f, 0.0f, 0.0f, 0.0f },
+	};
+	static UV_WORK* uvtble[2] = { BH_UVTAB0, BH_UVTAB1 };
+	O_WRK* fireman;
+	BH_PWORK* pl;
+	LGT_WORK* ent;
+	NJS_POINT3 v;
+	float ln;
+	float dz;
+	float dx;
+	UV_WORK* uvp;
+	int retry;
+
+	switch (op->mode0) {
+	case 0:
+		op->tex_id = 0x50;
+		op->ani_ct = 1;
+		bhEff_SetBaseColor(op, 0x80FFFFFF);
+		op->bl_src = 8;
+		op->bl_dst = 3;
+		if (op->type == 0) {
+			bhEff_SetAlign(op, op->flg | 0x4180000);
+			op->frm_no = (int)((-rand() / -2.1474836E9f) * 8.0f);
+		} else {
+			bhEff_SetAlign(op, op->flg | 0x24080000);
+			op->mtn_no = 0;
+			op->mtn_no = (int)((-rand() / -2.1474836E9f) * 2.0f);
+			op->frm_no = (int)((-rand() / -2.1474836E9f) * 8.0f);
+		}
+		op->sxb = op->sx;
+		op->syb = op->sy;
+		if (op->type == 1) {
+			op->ct3 = (int)((-rand() / -2.1474836E9f) * 200.0f) + 200;
+		} else if (op->type == 2) {
+			op->ct3 = 20;
+		}
+		op->ct0 = 0;
+		op->aw = 0.2f;
+		op->ah = 1.0f;
+		if (op->type == 1) {
+			ent = &rom->lgtp[1];
+			retry = ent->flg;
+			if (!(retry & 1)) {
+				ent->ct0 = 0;
+				ent->lkono = 0;
+				ent->vx = 0;
+				ent->vy = 0;
+				ent->vz = 0;
+			}
+			ent->lkono += 1;
+			ent->flg |= 3;
+			ent->type = 0xD;
+			ent->aspd = 2;
+			ent->lkflg = 0;
+			ent->lsrc = 4;
+			ent->nr = 15.0f;
+			ent->fr = ((float)ent->lkono / 10.0f) + 20.0f;
+			ent->vx += op->px;
+			ent->vy += op->py;
+			ent->vz += op->pz;
+			ent->px = ent->vx / (float)ent->lkono;
+			ent->py = ent->vy / (float)ent->lkono;
+			ent->pz = ent->vz / (float)ent->lkono;
+			ent->r = 3;
+			ent->g = 1.3f;
+			ent->b = 0.3f;
+		}
+		/* fallthrough */
+	case 1:
+		op->mode0++;
+		break;
+	case 2:
+		if (op->type != 0) {
+			if (bhEne_CheckPlayEffectSE(0x12303) == 0) {
+				bhEne_CallEffectSE((NJS_POINT3*)&op->px, 0x12303);
+			}
+		}
+		op->ct0 += 0.2f;
+		if (op->ct0 <= 1.0f) {
+			op->mode0++;
+			break;
+		}
+		op->ct0 = 1.0f;
+		op->mode0++;
+		break;
+	case 3:
+		if (op->type != 0) {
+			if (op->ct3 != 0) {
+				op->ct3--;
+				if (op->ct3 == 0) op->mode0++;
+			} else if (op->mode1 == 2) {
+				op->mode0++;
+			}
+		}
+		if (op->type == 0) {
+			pl = plp;
+			dx = pl->px - op->px;
+			dz = pl->pz - op->pz;
+			ln = njSqrt(dx * dx + dz * dz);
+			if (ln < pl->ar + 1.5f) {
+				pl->px += (dx * (pl->ar + 1.5f)) / ln;
+				pl->pz += (dz * (pl->ar + 1.5f)) / ln;
+				if (!(pl->flg & 4) && !(pl->stflg & 0x80000000) && !(sys->cb_flg & 4)) {
+					pl->flg |= 0x10004;
+				}
+				pl->stflg |= 0x10004;
+				pl->ax = (int)ln;
+				pl->ay = 0;
+				pl->az = (int)dz;
+				bhEne_DGDirCheck(pl);
+				pl->mode1 = 0;
+				pl->mode0 = 0;
+			}
+		}
+		if (op->ct3 == 0) break;
+		if (op->type == 0) {
+			sys->ef_flg |= 0x108;
+			bhSetEffectTb(&sys->ef, NULL, NULL, 1);
+			op->ct3 = (int)((-rand() / -2.1474836E9f) * 200.0f) + 200;
+			break;
+		}
+		op->aw -= 0.02f;
+		if (op->aw < 0.01f) {
+			op->aw = 0.01f;
+			op->ah = 0.9f;
+			op->ct3 = 0x80;
+			op->mode0++;
+			break;
+		}
+		break;
+	case 4:
+		op->ct3 -= 8;
+		op->aw -= 0.001f;
+		op->ah -= 0.002f;
+		if (op->ct3 >= 0) break;
+		if (op->type == 0) {
+			op->flg = 0;
+			break;
+		}
+		op->mode0++;
+		break;
+	case 5:
+		if (op->mode1 == 1) op->mode0++;
+		break;
+	case 6:
+		break;
+	}
+
+	uvp = &uvtble[op->mtn_no][op->frm_no];
+	op->frm_no++;
+	if (uvtble[op->mtn_no][op->frm_no].u < 0.0f) op->frm_no = 0;
+	bhEff_SetUVInfo(op, uvp, 0.09375f);
+
+	op->sx = op->sxb * op->aw;
+	op->sy = op->syb * op->aw;
+	if (op->mdlver == 0.0f) {
+		njCalcVector((NJS_MATRIX*)cam.mtx, (NJS_VECTOR*)&op->aox, (NJS_VECTOR*)&v);
+		op->sx *= fabsf(v.z * 0.5f) + 0.5f;
+	}
+	if (op->type != 0) {
+		op->ay = bhArcTan2(*((float*)cam.mtx + 10), *((float*)cam.mtx + 8));
+	}
+	if (op->type == 0) {
+		if (sys->ef_fncn < 0x80) {
+			sys->ef_fnc[sys->ef_fncn++] = op;
+		}
+	} else {
+		fireman = (O_WRK*)op->exp1;
+		if (fireman->ct0 < 300) {
+			((O_WRK**)(fireman->exp0 + 4))[fireman->ct0] = op;
+			fireman->ct0++;
+		}
+	}
+}
+
+#if 0
+void bhEff_E12_Fire_orig(O_WRK* op)
 {
 	O_WRK** ent;
 	O_WRK* fireman;
@@ -2822,6 +3306,7 @@ void bhEff_E12_Fire(O_WRK* op)
 	// Func End, Address: 0x242d38, Func Offset: 0xa18
 	scePrintf("bhEff_E12_Fire - UNIMPLEMENTED!\n");
 }
+#endif
 
 // 100% matching!
 void bhEff_E12_FrameLiquid(O_WRK* op) 

--- a/src/ps2/veronica/prog/en16.c
+++ b/src/ps2/veronica/prog/en16.c
@@ -1584,38 +1584,38 @@ void bhEne16_MV02(BH_PWORK* epw)
 	// Line 537, Address: 0x1eaa54, Func Offset: 0x9f4
 	// Func End, Address: 0x1eaa78, Func Offset: 0xa18
 }
+*/
 
-// 
-// Start address: 0x1eaa80
 int bhEne16_GetEffNum(BH_PWORK* epw)
 {
-	// Line 548, Address: 0x1eaa80, Func Offset: 0
-	// Line 549, Address: 0x1eaa84, Func Offset: 0x4
-	// Func End, Address: 0x1eaa8c, Func Offset: 0xc
+	return *(int*)(epw->exp0 + 0x64);
 }
 
-// 
-// Start address: 0x1eaa90
-_anon14* bhEne16_GetEffPos(BH_PWORK* epw)
+NJS_POINT3* bhEne16_GetEffPos(BH_PWORK* epw)
 {
-	// Line 560, Address: 0x1eaa90, Func Offset: 0
-	// Line 561, Address: 0x1eaa94, Func Offset: 0x4
-	// Func End, Address: 0x1eaa9c, Func Offset: 0xc
+	return (NJS_POINT3*)(epw->exp0 + 0x4);
 }
 
-// 
-// Start address: 0x1eaaa0
-void bhEne16_AddEffPos(BH_PWORK* epw, _anon14* pos)
+void bhEne16_AddEffPos(BH_PWORK* epw, NJS_POINT3* pos)
 {
+	NJS_POINT3* entries;
+	int count;
 	int i;
-	// Line 574, Address: 0x1eaaa0, Func Offset: 0
-	// Line 575, Address: 0x1eaabc, Func Offset: 0x1c
-	// Line 576, Address: 0x1eaac0, Func Offset: 0x20
-	// Line 575, Address: 0x1eaac4, Func Offset: 0x24
-	// Line 576, Address: 0x1eaae0, Func Offset: 0x40
-	// Line 577, Address: 0x1eaae8, Func Offset: 0x48
-	// Line 578, Address: 0x1eab04, Func Offset: 0x64
-	// Line 579, Address: 0x1eab28, Func Offset: 0x88
-	// Func End, Address: 0x1eab30, Func Offset: 0x90
-}*/
+
+	entries = (NJS_POINT3*)(epw->exp0 + 0x4);
+	count = *(int*)(epw->exp0 + 0x64);
+
+	for (i = count - 1; i > 0; i--)
+	{
+		entries[i] = entries[i - 1];
+	}
+
+	entries[0] = *pos;
+
+	count = *(int*)(epw->exp0 + 0x64);
+	if (count < 7)
+	{
+		*(int*)(epw->exp0 + 0x64) = count + 1;
+	}
+}
 

--- a/src/ps2/veronica/prog/hitchk.c
+++ b/src/ps2/veronica/prog/hitchk.c
@@ -4418,6 +4418,97 @@ int bhCheckBox2Box(ATR_WORK* hp, NJS_POINT3* pos, float aw, float ad, float ah)
 // Start address: 0x265e10
 int bhCheckInnerP4(NJS_POINT2* pos, NJS_POINT2* p0, NJS_POINT2* p1, NJS_POINT2* p2, NJS_POINT2* p3)
 {
+	float dx01, dy01, dy02, dy13, dy23;
+	float slopeA, slopeB;
+	float xa, xb, tmp;
+	float slopeC, slopeD;
+
+	if (pos->y >= p0->y) {
+		if (pos->y >= p3->y) return 0;
+
+		dx01 = p1->x - p0->x;
+		dy01 = p1->y - p0->y;
+		dy02 = p2->y - p0->y;
+		dy13 = p3->y - p1->y;
+		dy23 = p3->y - p2->y;
+
+		slopeA = 0.0f;
+		slopeB = 0.0f;
+		if (!(dx01 <= 0.0f)) {
+			if (dy02 != 0.0f) slopeA = (p2->x - p0->x) / dy02;
+			if (dy01 != 0.0f) slopeB = dx01 / dy01;
+		} else {
+			if (dy01 != 0.0f) slopeA = dx01 / dy01;
+			if (dy02 != 0.0f) slopeB = (p2->x - p0->x) / dy02;
+		}
+
+		if (pos->y < p1->y) {
+			xa = p0->x + (slopeA * (pos->y - p0->y));
+			xb = p0->x + (slopeB * (pos->y - p0->y));
+			if (!(xa <= xb)) { tmp = xa; xa = xb; xb = tmp; }
+			if (xa <= pos->x) {
+				if (xb <= pos->x) return 0;
+				return 1;
+			}
+			return 0;
+		}
+
+		if (pos->y < p2->y) {
+			slopeC = 0.0f;
+			if (!(dx01 <= 0.0f)) {
+				if (dy13 != 0.0f) slopeC = (p3->x - p1->x) / dy13;
+				xa = p0->x + (slopeA * (pos->y - p0->y));
+				xb = p1->x + (slopeC * (pos->y - p1->y));
+				if (!(xa <= xb)) { tmp = xa; xa = xb; xb = tmp; }
+				if (xa <= pos->x) {
+					if (xb <= pos->x) return 0;
+					return 1;
+				}
+				return 0;
+			}
+			if (dy13 != 0.0f) slopeC = (p3->x - p1->x) / dy13;
+			xa = p1->x + (slopeC * (pos->y - p1->y));
+			xb = p0->x + (slopeB * (pos->y - p0->y));
+			if (!(xa <= xb)) { tmp = xa; xa = xb; xb = tmp; }
+			if (xa <= pos->x) {
+				if (xb <= pos->x) return 0;
+				return 1;
+			}
+			return 0;
+		}
+
+		slopeC = 0.0f;
+		if (!(dx01 <= 0.0f)) {
+			if (dy13 != 0.0f) slopeC = (p3->x - p1->x) / dy13;
+			slopeD = 0.0f;
+			if (dy23 != 0.0f) slopeD = (p3->x - p2->x) / dy23;
+			xa = p2->x + (slopeD * (pos->y - p2->y));
+			xb = p1->x + (slopeC * (pos->y - p1->y));
+			if (!(xa <= xb)) { tmp = xa; xa = xb; xb = tmp; }
+			if (xa <= pos->x) {
+				if (xb <= pos->x) return 0;
+				return 1;
+			}
+			return 0;
+		}
+		if (dy13 != 0.0f) slopeC = (p3->x - p1->x) / dy13;
+		slopeD = 0.0f;
+		if (dy23 != 0.0f) slopeD = (p3->x - p2->x) / dy23;
+		xa = p1->x + (slopeC * (pos->y - p1->y));
+		xb = p2->x + (slopeD * (pos->y - p2->y));
+		if (!(xa <= xb)) { tmp = xa; xa = xb; xb = tmp; }
+		if (xa <= pos->x) {
+			if (xb <= pos->x) return 0;
+			return 1;
+		}
+		return 0;
+	}
+	return 0;
+}
+
+#if 0
+int bhCheckInnerP4_orig(NJS_POINT2* pos, NJS_POINT2* p0, NJS_POINT2* p1, NJS_POINT2* p2, NJS_POINT2* p3)
+{
 	float y3;
 	float y2;
 	float y1;
@@ -4511,6 +4602,7 @@ int bhCheckInnerP4(NJS_POINT2* pos, NJS_POINT2* p0, NJS_POINT2* p1, NJS_POINT2* 
 	// Func End, Address: 0x266270, Func Offset: 0x460
 	scePrintf("bhCheckInnerP4 - UNIMPLEMENTED!\n");
 }
+#endif
 
 // 100% matching!
 void bhCheckExmAtari(BH_PWORK* pp)

--- a/src/ps2/veronica/prog/ps2_NaColi.c
+++ b/src/ps2/veronica/prog/ps2_NaColi.c
@@ -975,6 +975,106 @@ Int     njCollisionCheckBC(NJS_BOX *box, NJS_CAPSULE *capsule)
 // Start address: 0x2e4bc0
 int njCheckPlane4AndLine(NJS_POINT3* pP1, NJS_POINT3* pP2, NJS_POINT3* pP3, NJS_POINT3* pP4, NJS_POINT3* pPN, NJS_LINE* pLine)
 {
+	float len2, invlen;
+	float ndx, ndy, ndz;
+	float dot;
+	float t;
+	float ix, iy, iz;
+	float dx, dy, dz;
+	float d1, d2;
+	float ux1, uy1, uz1;
+	float ux2, uy2, uz2;
+	float ux3, uy3, uz3;
+	float ux4, uy4, uz4;
+	float dot1, dot2, dot3, dot4;
+	float sum;
+
+	len2 = pLine->vx * pLine->vx + pLine->vy * pLine->vy + pLine->vz * pLine->vz;
+	invlen = njInvertSqrt(len2);
+	ndx = pLine->vx * invlen;
+	ndy = pLine->vy * invlen;
+	ndz = pLine->vz * invlen;
+
+	dot = pPN->x * ndx + pPN->y * ndy + pPN->z * ndz;
+	if (fabsf(dot) <= 0.025f) return 0;
+
+	t = -(pPN->x * (pLine->px - pP1->x) + pPN->y * (pLine->py - pP1->y) + pPN->z * (pLine->pz - pP1->z)) / dot;
+
+	ix = pLine->px + ndx * t;
+	iy = pLine->py + ndy * t;
+	iz = pLine->pz + ndz * t;
+
+	dx = ix - pLine->px;
+	dy = iy - pLine->py;
+	dz = iz - pLine->pz;
+	if (len2 < dx * dx + dy * dy + dz * dz) return 0;
+
+	dx = ix - (pLine->px + pLine->vx);
+	dy = iy - (pLine->py + pLine->vy);
+	dz = iz - (pLine->pz + pLine->vz);
+	if (len2 < dx * dx + dy * dy + dz * dz) return 0;
+
+	dx = pP1->x - ix;
+	dy = pP1->y - iy;
+	dz = pP1->z - iz;
+	d1 = dx * dx + dy * dy + dz * dz;
+	if (d1 < 0.001f) return 1;
+	invlen = njInvertSqrt(d1);
+	ux1 = dx * invlen;
+	uy1 = dy * invlen;
+	uz1 = dz * invlen;
+
+	dx = pP2->x - ix;
+	dy = pP2->y - iy;
+	dz = pP2->z - iz;
+	d2 = dx * dx + dy * dy + dz * dz;
+	if (d2 < 0.001f) return 1;
+	invlen = njInvertSqrt(d2);
+	ux2 = dx * invlen;
+	uy2 = dy * invlen;
+	uz2 = dz * invlen;
+
+	dx = pP3->x - ix;
+	dy = pP3->y - iy;
+	dz = pP3->z - iz;
+	d1 = dx * dx + dy * dy + dz * dz;
+	if (d1 < 0.001f) return 1;
+	invlen = njInvertSqrt(d1);
+	ux3 = dx * invlen;
+	uy3 = dy * invlen;
+	uz3 = dz * invlen;
+
+	dx = pP4->x - ix;
+	dy = pP4->y - iy;
+	dz = pP4->z - iz;
+	d2 = dx * dx + dy * dy + dz * dz;
+	if (d2 < 0.001f) return 1;
+	invlen = njInvertSqrt(d2);
+	ux4 = dx * invlen;
+	uy4 = dy * invlen;
+	uz4 = dz * invlen;
+
+	dot1 = ux1 * ux2 + uy1 * uy2 + uz1 * uz2;
+	if (dot1 < -1.0f) return 0;
+	if (dot1 > 1.0f) return 0;
+	dot2 = ux2 * ux3 + uy2 * uy3 + uz2 * uz3;
+	if (dot2 < -1.0f) return 0;
+	if (dot2 > 1.0f) return 0;
+	dot3 = ux3 * ux4 + uy3 * uy4 + uz3 * uz4;
+	if (dot3 < -1.0f) return 0;
+	if (dot3 > 1.0f) return 0;
+	dot4 = ux4 * ux1 + uy4 * uy1 + uz4 * uz1;
+	if (dot4 < -1.0f) return 0;
+	if (dot4 > 1.0f) return 0;
+
+	sum = acosf(dot1) + acosf(dot2) + acosf(dot3) + acosf(dot4);
+	if (sum < 6.25f) return 0;
+	return 1;
+}
+
+#if 0
+int njCheckPlane4AndLine_orig(NJS_POINT3* pP1, NJS_POINT3* pP2, NJS_POINT3* pP3, NJS_POINT3* pP4, NJS_POINT3* pPN, NJS_LINE* pLine)
+{
 	float fT4;
 	float fT3;
 	float fT2;
@@ -1091,6 +1191,8 @@ int njCheckPlane4AndLine(NJS_POINT3* pP1, NJS_POINT3* pP2, NJS_POINT3* pP3, NJS_
 	// Func End, Address: 0x2e5084, Func Offset: 0x4c4
     scePrintf("njCheckPlane4AndLine - UNIMPLEMENTED!\n");
 }
+#endif
+
 
 // 100% matching!
 int njCollisionCheckBC2(NJS_BOX* pBox, NJS_CAPSULE* pCapsule) 

--- a/src/ps2/veronica/prog/sub1.c
+++ b/src/ps2/veronica/prog/sub1.c
@@ -7753,18 +7753,14 @@ void ItemBox(S_WORK* st)
 
 #pragma	divbyzerocheck off
 
-// 
+//
 // Start address: 0x2a53e0
 void ItemBoxChange(S_WORK* st, unsigned short ibcsr)
 {
-	unsigned char max;
 	unsigned char chk2;
-	unsigned char bmax;
 	unsigned short y;
 	unsigned short x;
-	unsigned short arms;
 	unsigned short bullet;
-	unsigned short wpn;
 	unsigned short lt_c3;
 	unsigned short lt_c2;
 	unsigned short lt_c;
@@ -7775,181 +7771,304 @@ void ItemBoxChange(S_WORK* st, unsigned short ibcsr)
 	unsigned int itemid3;
 	unsigned int itemid2;
 	unsigned int itemid1;
-	// Line 6049, Address: 0x2a53e0, Func Offset: 0
-	// Line 6068, Address: 0x2a5408, Func Offset: 0x28
-	// Line 6070, Address: 0x2a540c, Func Offset: 0x2c
-	// Line 6071, Address: 0x2a5414, Func Offset: 0x34
-	// Line 6076, Address: 0x2a541c, Func Offset: 0x3c
-	// Line 6071, Address: 0x2a5424, Func Offset: 0x44
-	// Line 6070, Address: 0x2a5428, Func Offset: 0x48
-	// Line 6074, Address: 0x2a5430, Func Offset: 0x50
-	// Line 6070, Address: 0x2a5434, Func Offset: 0x54
-	// Line 6076, Address: 0x2a5438, Func Offset: 0x58
-	// Line 6071, Address: 0x2a543c, Func Offset: 0x5c
-	// Line 6056, Address: 0x2a5444, Func Offset: 0x64
-	// Line 6072, Address: 0x2a5448, Func Offset: 0x68
-	// Line 6065, Address: 0x2a5450, Func Offset: 0x70
-	// Line 6068, Address: 0x2a5454, Func Offset: 0x74
-	// Line 6074, Address: 0x2a5458, Func Offset: 0x78
-	// Line 6073, Address: 0x2a5464, Func Offset: 0x84
-	// Line 6072, Address: 0x2a5468, Func Offset: 0x88
-	// Line 6073, Address: 0x2a546c, Func Offset: 0x8c
-	// Line 6074, Address: 0x2a5470, Func Offset: 0x90
-	// Line 6076, Address: 0x2a5474, Func Offset: 0x94
-	// Line 6077, Address: 0x2a547c, Func Offset: 0x9c
-	// Line 6080, Address: 0x2a54c8, Func Offset: 0xe8
-	// Line 6081, Address: 0x2a54d8, Func Offset: 0xf8
-	// Line 6080, Address: 0x2a54e0, Func Offset: 0x100
-	// Line 6081, Address: 0x2a54e8, Func Offset: 0x108
-	// Line 6082, Address: 0x2a54f0, Func Offset: 0x110
-	// Line 6083, Address: 0x2a54f8, Func Offset: 0x118
-	// Line 6084, Address: 0x2a5548, Func Offset: 0x168
-	// Line 6085, Address: 0x2a5558, Func Offset: 0x178
-	// Line 6084, Address: 0x2a5560, Func Offset: 0x180
-	// Line 6085, Address: 0x2a5568, Func Offset: 0x188
-	// Line 6086, Address: 0x2a5570, Func Offset: 0x190
-	// Line 6087, Address: 0x2a5578, Func Offset: 0x198
-	// Line 6092, Address: 0x2a55a8, Func Offset: 0x1c8
-	// Line 6093, Address: 0x2a55b8, Func Offset: 0x1d8
-	// Line 6092, Address: 0x2a55c0, Func Offset: 0x1e0
-	// Line 6093, Address: 0x2a55c8, Func Offset: 0x1e8
-	// Line 6094, Address: 0x2a55d0, Func Offset: 0x1f0
-	// Line 6099, Address: 0x2a55d8, Func Offset: 0x1f8
-	// Line 6102, Address: 0x2a55f0, Func Offset: 0x210
-	// Line 6099, Address: 0x2a55f4, Func Offset: 0x214
-	// Line 6102, Address: 0x2a55f8, Func Offset: 0x218
-	// Line 6103, Address: 0x2a560c, Func Offset: 0x22c
-	// Line 6104, Address: 0x2a561c, Func Offset: 0x23c
-	// Line 6105, Address: 0x2a563c, Func Offset: 0x25c
-	// Line 6106, Address: 0x2a5640, Func Offset: 0x260
-	// Line 6107, Address: 0x2a5650, Func Offset: 0x270
-	// Line 6109, Address: 0x2a5658, Func Offset: 0x278
-	// Line 6107, Address: 0x2a565c, Func Offset: 0x27c
-	// Line 6109, Address: 0x2a5660, Func Offset: 0x280
-	// Line 6111, Address: 0x2a5678, Func Offset: 0x298
-	// Line 6113, Address: 0x2a56a4, Func Offset: 0x2c4
-	// Line 6114, Address: 0x2a56b4, Func Offset: 0x2d4
-	// Line 6115, Address: 0x2a56c4, Func Offset: 0x2e4
-	// Line 6117, Address: 0x2a56fc, Func Offset: 0x31c
-	// Line 6119, Address: 0x2a5708, Func Offset: 0x328
-	// Line 6118, Address: 0x2a570c, Func Offset: 0x32c
-	// Line 6120, Address: 0x2a5710, Func Offset: 0x330
-	// Line 6122, Address: 0x2a5714, Func Offset: 0x334
-	// Line 6123, Address: 0x2a571c, Func Offset: 0x33c
-	// Line 6125, Address: 0x2a5728, Func Offset: 0x348
-	// Line 6124, Address: 0x2a572c, Func Offset: 0x34c
-	// Line 6126, Address: 0x2a5730, Func Offset: 0x350
-	// Line 6130, Address: 0x2a5734, Func Offset: 0x354
-	// Line 6131, Address: 0x2a573c, Func Offset: 0x35c
-	// Line 6133, Address: 0x2a5768, Func Offset: 0x388
-	// Line 6134, Address: 0x2a5778, Func Offset: 0x398
-	// Line 6135, Address: 0x2a5784, Func Offset: 0x3a4
-	// Line 6136, Address: 0x2a578c, Func Offset: 0x3ac
-	// Line 6139, Address: 0x2a579c, Func Offset: 0x3bc
-	// Line 6141, Address: 0x2a57a4, Func Offset: 0x3c4
-	// Line 6142, Address: 0x2a57b4, Func Offset: 0x3d4
-	// Line 6144, Address: 0x2a57e8, Func Offset: 0x408
-	// Line 6145, Address: 0x2a57f4, Func Offset: 0x414
-	// Line 6147, Address: 0x2a5800, Func Offset: 0x420
-	// Line 6146, Address: 0x2a5804, Func Offset: 0x424
-	// Line 6148, Address: 0x2a5808, Func Offset: 0x428
-	// Line 6150, Address: 0x2a580c, Func Offset: 0x42c
-	// Line 6151, Address: 0x2a5814, Func Offset: 0x434
-	// Line 6153, Address: 0x2a581c, Func Offset: 0x43c
-	// Line 6154, Address: 0x2a5824, Func Offset: 0x444
-	// Line 6156, Address: 0x2a5828, Func Offset: 0x448
-	// Line 6158, Address: 0x2a5830, Func Offset: 0x450
-	// Line 6160, Address: 0x2a5864, Func Offset: 0x484
-	// Line 6161, Address: 0x2a5868, Func Offset: 0x488
-	// Line 6162, Address: 0x2a586c, Func Offset: 0x48c
-	// Line 6169, Address: 0x2a5870, Func Offset: 0x490
-	// Line 6170, Address: 0x2a587c, Func Offset: 0x49c
-	// Line 6171, Address: 0x2a588c, Func Offset: 0x4ac
-	// Line 6173, Address: 0x2a5890, Func Offset: 0x4b0
-	// Line 6174, Address: 0x2a58a0, Func Offset: 0x4c0
-	// Line 6175, Address: 0x2a58ac, Func Offset: 0x4cc
-	// Line 6177, Address: 0x2a58c4, Func Offset: 0x4e4
-	// Line 6179, Address: 0x2a58dc, Func Offset: 0x4fc
-	// Line 6178, Address: 0x2a58e4, Func Offset: 0x504
-	// Line 6180, Address: 0x2a58e8, Func Offset: 0x508
-	// Line 6181, Address: 0x2a58ec, Func Offset: 0x50c
-	// Line 6182, Address: 0x2a58f0, Func Offset: 0x510
-	// Line 6186, Address: 0x2a5908, Func Offset: 0x528
-	// Line 6187, Address: 0x2a5918, Func Offset: 0x538
-	// Line 6188, Address: 0x2a591c, Func Offset: 0x53c
-	// Line 6191, Address: 0x2a5920, Func Offset: 0x540
-	// Line 6193, Address: 0x2a592c, Func Offset: 0x54c
-	// Line 6194, Address: 0x2a5938, Func Offset: 0x558
-	// Line 6198, Address: 0x2a5940, Func Offset: 0x560
-	// Line 6194, Address: 0x2a5944, Func Offset: 0x564
-	// Line 6195, Address: 0x2a5950, Func Offset: 0x570
-	// Line 6196, Address: 0x2a5954, Func Offset: 0x574
-	// Line 6195, Address: 0x2a5958, Func Offset: 0x578
-	// Line 6196, Address: 0x2a595c, Func Offset: 0x57c
-	// Line 6197, Address: 0x2a5964, Func Offset: 0x584
-	// Line 6198, Address: 0x2a5970, Func Offset: 0x590
-	// Line 6202, Address: 0x2a5988, Func Offset: 0x5a8
-	// Line 6201, Address: 0x2a5990, Func Offset: 0x5b0
-	// Line 6202, Address: 0x2a599c, Func Offset: 0x5bc
-	// Line 6204, Address: 0x2a59a4, Func Offset: 0x5c4
-	// Line 6213, Address: 0x2a59c0, Func Offset: 0x5e0
-	// Line 6215, Address: 0x2a59e0, Func Offset: 0x600
-	// Line 6217, Address: 0x2a5a2c, Func Offset: 0x64c
-	// Line 6218, Address: 0x2a5a38, Func Offset: 0x658
-	// Line 6220, Address: 0x2a5a40, Func Offset: 0x660
-	// Line 6221, Address: 0x2a5a50, Func Offset: 0x670
-	// Line 6222, Address: 0x2a5a58, Func Offset: 0x678
-	// Line 6223, Address: 0x2a5a80, Func Offset: 0x6a0
-	// Line 6224, Address: 0x2a5aac, Func Offset: 0x6cc
-	// Line 6225, Address: 0x2a5ad8, Func Offset: 0x6f8
-	// Line 6226, Address: 0x2a5ae4, Func Offset: 0x704
-	// Line 6230, Address: 0x2a5ae8, Func Offset: 0x708
-	// Line 6231, Address: 0x2a5af8, Func Offset: 0x718
-	// Line 6232, Address: 0x2a5b24, Func Offset: 0x744
-	// Line 6233, Address: 0x2a5b30, Func Offset: 0x750
-	// Line 6234, Address: 0x2a5b5c, Func Offset: 0x77c
-	// Line 6240, Address: 0x2a5b60, Func Offset: 0x780
-	// Line 6241, Address: 0x2a5b68, Func Offset: 0x788
-	// Line 6242, Address: 0x2a5b90, Func Offset: 0x7b0
-	// Line 6243, Address: 0x2a5bbc, Func Offset: 0x7dc
-	// Line 6248, Address: 0x2a5bc0, Func Offset: 0x7e0
-	// Line 6250, Address: 0x2a5be0, Func Offset: 0x800
-	// Line 6251, Address: 0x2a5be4, Func Offset: 0x804
-	// Line 6250, Address: 0x2a5bf4, Func Offset: 0x814
-	// Line 6251, Address: 0x2a5c00, Func Offset: 0x820
-	// Line 6250, Address: 0x2a5c10, Func Offset: 0x830
-	// Line 6251, Address: 0x2a5c14, Func Offset: 0x834
-	// Line 6252, Address: 0x2a5c4c, Func Offset: 0x86c
-	// Line 6255, Address: 0x2a5c58, Func Offset: 0x878
-	// Line 6256, Address: 0x2a5c64, Func Offset: 0x884
-	// Line 6257, Address: 0x2a5c98, Func Offset: 0x8b8
-	// Line 6258, Address: 0x2a5cf0, Func Offset: 0x910
-	// Line 6260, Address: 0x2a5cfc, Func Offset: 0x91c
-	// Line 6261, Address: 0x2a5d38, Func Offset: 0x958
-	// Line 6265, Address: 0x2a5d44, Func Offset: 0x964
-	// Line 6266, Address: 0x2a5d60, Func Offset: 0x980
-	// Line 6267, Address: 0x2a5d6c, Func Offset: 0x98c
-	// Line 6269, Address: 0x2a5d70, Func Offset: 0x990
-	// Line 6270, Address: 0x2a5d84, Func Offset: 0x9a4
-	// Line 6271, Address: 0x2a5da4, Func Offset: 0x9c4
-	// Line 6272, Address: 0x2a5db4, Func Offset: 0x9d4
-	// Line 6273, Address: 0x2a5dbc, Func Offset: 0x9dc
-	// Line 6272, Address: 0x2a5dc4, Func Offset: 0x9e4
-	// Line 6274, Address: 0x2a5de4, Func Offset: 0xa04
-	// Line 6275, Address: 0x2a5dec, Func Offset: 0xa0c
-	// Line 6276, Address: 0x2a5df8, Func Offset: 0xa18
-	// Line 6277, Address: 0x2a5e14, Func Offset: 0xa34
-	// Line 6278, Address: 0x2a5e18, Func Offset: 0xa38
-	// Line 6279, Address: 0x2a5e20, Func Offset: 0xa40
-	// Line 6276, Address: 0x2a5e24, Func Offset: 0xa44
-	// Line 6279, Address: 0x2a5e28, Func Offset: 0xa48
-	// Line 6281, Address: 0x2a5e3c, Func Offset: 0xa5c
-	// Line 6282, Address: 0x2a5e44, Func Offset: 0xa64
-	// Line 6283, Address: 0x2a5e54, Func Offset: 0xa74
-	// Line 6284, Address: 0x2a5e5c, Func Offset: 0xa7c
-	// Line 6287, Address: 0x2a5e78, Func Offset: 0xa98
-	// Func End, Address: 0x2a5ea4, Func Offset: 0xac4
-	scePrintf("ItemBoxChange - UNIMPLEMENTED!\n");
+	unsigned int num1x;
+	unsigned int idx;
+	unsigned int i;
+
+	num1 = (unsigned short)st->listcsr_0;
+	itemid1 = st->pip[num1];
+	itemid3 = st->bxp[ibcsr];
+	itemid2 = st->pip[st->pip[0]];
+	id2 = (unsigned short)((itemid1 >> 16) & 0xff);
+	id1 = (unsigned short)((itemid3 >> 16) & 0xff);
+	x = (unsigned short)((itemid2 >> 16) & 0xff);
+
+	if (sys->ply_id == 0)
+	{
+		if ((itemdata[id1].type & 0x40))
+		{
+			if ((sys->stg_no == 9) && (sys->rom_no == 0x1a))
+			{
+				st->statusflg &= ~0x100000;
+				bhSetMessage(1, 0x97);
+				return;
+			}
+		}
+
+		if ((itemdata[id2].type & 0x40))
+		{
+			if (((itemdata[id2].type & 0x400) == 0x69) || ((itemdata[id2].type & 0x400) == 0x6a) || ((itemdata[id2].type & 0x400) == 0x79))
+			{
+				st->statusflg &= ~0x100000;
+				bhSetMessage(1, 0x96);
+				return;
+			}
+		}
+
+		if (!(itemdata[id2].type & 0x400))
+		{
+			if ((id2 != 0) && (sys->stg_no == 0) && (sys->rom_no == 9))
+			{
+				st->statusflg &= ~0x100000;
+				bhSetMessage(1, 0xc8);
+				return;
+			}
+		}
+	}
+
+	chk = (sys->gm_flg & 0x800) ? 10 : 8;
+
+	lt_c = 0;
+	lt_c2 = chk;
+	for (i = 0; lt_c < chk; i += 4)
+	{
+		bullet = (unsigned short)((st->pip[i / 4 + 2] >> 16) & 0xff);
+
+		if ((itemdata[bullet].type & 0x100))
+		{
+			lt_c2 -= 2;
+		}
+		else if (bullet != 0)
+		{
+			lt_c2 -= 1;
+		}
+
+		lt_c += 1;
+	}
+
+	chk2 = 0;
+	num1x = 0;
+	idx = 0;
+
+	if ((itemdata[id1].type & 0x100))
+	{
+		if (num1 == 1)
+		{
+			if (lt_c2 >= 2)
+			{
+				if (id2 == standard[sys->ply_id][0])
+				{
+					num1x = chk + 1;
+					idx = num1;
+					chk2 = 1;
+				}
+				else if (id2 == standard[sys->ply_id][1])
+				{
+					num1x = chk + 1;
+					idx = num1;
+					chk2 = 1;
+				}
+				else
+				{
+					num1x = chk + 1;
+					idx = id2;
+					chk2 = 1;
+				}
+			}
+		}
+		else if ((itemdata[id2].type & 0x100))
+		{
+			chk2 = 1;
+		}
+		else if (id2 == 0)
+		{
+			if (lt_c2 >= 2)
+			{
+				chk2 = 1;
+			}
+		}
+		else if (lt_c2 > 0)
+		{
+			chk2 = 1;
+		}
+	}
+	else if (num1 == 1)
+	{
+		if ((id1 == standard[sys->ply_id][0]) || (id1 == standard[sys->ply_id][1]))
+		{
+			chk2 = 1;
+		}
+		else if (lt_c2 > 0)
+		{
+			num1x = chk + 1;
+			itemid3 = 0;
+			idx = id2;
+			chk2 = 1;
+		}
+		else if (id1 == 0)
+		{
+			chk2 = 1;
+		}
+	}
+	else if ((id1 == standard[sys->ply_id][0]) || (id1 == standard[sys->ply_id][1]))
+	{
+		chk2 = 1;
+	}
+
+	if ((itemdata[id1].type & 0x200))
+	{
+		if (id2 == id1)
+		{
+			chk2 = 2;
+		}
+		else if (id2 == 0)
+		{
+			for (lt_c3 = 0; lt_c3 < chk; lt_c3 += 1)
+			{
+				y = (unsigned short)((st->pip[lt_c3 + 2] >> 16) & 0xff);
+
+				if (y == id1)
+				{
+					if ((unsigned short)(st->pip[lt_c3 + 2] & 0xffff) < 999)
+					{
+						chk2 = 2;
+						break;
+					}
+				}
+			}
+		}
+	}
+
+	if (chk2 == 1)
+	{
+		if (st->pip[0] == num1)
+		{
+			parts_14b[0].atr &= ~0x20;
+
+			st->pip[0] = 0;
+			plp->mode3 = 0;
+			plp->wpnr_no = 0;
+
+			*(unsigned int*)&sys->mn_mode0 = 3;
+		}
+
+		st->bxp[ibcsr] = itemid1;
+		st->pip[idx] = itemid3;
+
+		if (num1x != 0)
+		{
+			st->pip[num1x] = 2;
+		}
+
+		if (st->pip[0] >= 2)
+		{
+			if (num1 == 1)
+			{
+				if ((itemdata[id2].type & 0x100))
+				{
+					y = (unsigned short)((st->pip[st->pip[0]] >> 16) & 0xff);
+
+					if (!(itemdata[y].type & 0x100))
+					{
+						st->pip[0]++;
+					}
+				}
+			}
+			else if ((id2 == 0) || (id2 == standard[sys->ply_id][0]) || (id2 == standard[sys->ply_id][1]))
+			{
+				if (num1 < st->pip[0])
+				{
+					st->pip[0]--;
+				}
+			}
+			else if (id1 == 0)
+			{
+				if ((itemdata[id2].type & 0x100))
+				{
+					if (!(itemdata[x].type & 0x100))
+					{
+						st->pip[0]++;
+					}
+				}
+			}
+			else if ((itemdata[id2].type & 0x100))
+			{
+				if (!(itemdata[id1].type & 0x100))
+				{
+					if (!(itemdata[x].type & 0x100))
+					{
+						if (st->pip[0] < num1)
+						{
+							st->pip[0]++;
+						}
+					}
+				}
+			}
+			else
+			{
+				if ((itemdata[id1].type & 0x100))
+				{
+					if (num1 < st->pip[0])
+					{
+						if ((itemdata[x].type & 0x100))
+						{
+							st->pip[0]--;
+						}
+					}
+				}
+			}
+		}
+
+		if (num1 != 1)
+		{
+			if ((sakai < st->listcsr_0) || ((st->listcsr_2 & 1) && (st->listcsr_0 == (sakai - 1))))
+			{
+				if ((itemdata[id2].type & 0x100) && !(itemdata[id1].type & 0x100))
+				{
+					st->listcsr_0++;
+				}
+			}
+
+			if ((itemdata[id1].type & 0x100) && !(itemdata[id2].type & 0x100))
+			{
+				st->listcsr_0--;
+			}
+		}
+
+		if (itemid1 != 0)
+		{
+			if (parts_15b[18].anim == 0x10)
+			{
+				parts_15b[18].anim = 0x11;
+				parts_15b[19].anim = 0x11;
+			}
+		}
+
+		return;
+	}
+
+	if (chk2 == 2)
+	{
+		short cmb_idx;
+		short num;
+
+		if (itemdata[id1].cmb < 0)
+		{
+			return;
+		}
+
+		cmb_idx = itemdata[id1].cmb + 1;
+		num = combidata[itemdata[id1].cmb];
+
+		while (num > 0)
+		{
+			if (id2 == combidata[cmb_idx])
+			{
+				Combi_01(cmb_idx, &st->bxp[ibcsr], &st->pip[num1]);
+			}
+
+			cmb_idx += 3;
+			num--;
+		}
+
+		return;
+	}
+
+	if (!(sys->st_flg & 0x200))
+	{
+		bhSetMessage(1, 0x9f);
+		st->statusflg &= ~0x100000;
+	}
 }
 
 // 100% matching!


### PR DESCRIPTION
Addresses the functions flagged in #49:

- bhCheckInnerP4 (hitchk.c) - 81.3%
- njCheckPlane4AndLine (ps2_NaColi.c) - 72.6%
- bhEff_E12_Fire, bhEff_E11_SearchLightDraw, bhEff_E16_LaserSightDraw (effsub2.c) - 63.3%, 74.3%, 74.1%
- ItemBoxChange (sub1.c) - 60.6%, plateaued after several passes, looks like an MWCC scheduling difference rather than a logic gap

njCheckPlane4IncludePoint was already solved on master, dropped it from this branch.

SearchLightDraw/LaserSightDraw needed NJS_POINT3COL fixed to its real shape (a {p, col, tex, num} descriptor, not a per-vertex array) - that alone took both from ~50-70% to ~74%.

LaserSightDraw also calls bhEne16_GetEffNum/GetEffPos/AddEffPos, which were still commented out in en16.c and broke the link - implemented those too (100%, 100%, 78%).

bhObj005 (water ripple + VU0) is still WIP locally, not included here.